### PR TITLE
Python 3 compability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ these:
 * `libsasl2-dev`
 * `libssl-dev`
 * `pkg-config`
-* `python-dev`
-* `python-pip`
+* `python3-dev`
+* `python3-pip`
 * `swig`
 
 ```sh
-$ pip install .
+$ pip3 install .
 ```

--- a/check_amqp1.0
+++ b/check_amqp1.0
@@ -133,7 +133,7 @@ try:
     np.add_status(ok)
     np.add_summary("Received message %r" % (recv_msg))
 
-except Exception, e:
+except Exception as e:
   np.add_status(critical)
   np.add_summary('%s: %r' % (e.__class__.__name__, e))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-qpid-proton>=0.11.1
+python-qpid-proton>=0.35.0
 pynag>=0.9.1

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # vim: set fileencoding=utf-8
 '''
 Nagios NRPE check for checking the AMQP 1.0 connection to a server (like check aliveness does)
@@ -10,7 +10,7 @@ Licensed under the Revised BSD License.
 import sys
 from setuptools import setup, find_packages
 
-version = "1.1.0"
+version = "1.2.0"
 
 setup(
     name="check_amqp1.0",


### PR DESCRIPTION
We need to move to python3 as installable versions of python-qpid-proton is python 3 only.